### PR TITLE
Added pixel_size column to grids table

### DIFF
--- a/db/migrate/20190826174250_add_pixel_size_to_grids.rb
+++ b/db/migrate/20190826174250_add_pixel_size_to_grids.rb
@@ -1,0 +1,5 @@
+class AddPixelSizeToGrids < ActiveRecord::Migration[5.2]
+  def change
+    add_column :grids, :pixel_size, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_26_124736) do
+ActiveRecord::Schema.define(version: 2019_08_26_174250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_08_26_124736) do
     t.integer "width"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "pixel_size"
   end
 
   create_table "pixels", force: :cascade do |t|


### PR DESCRIPTION
Column will store integer of pixel side length. Useful for testing and creating different sized grids.