### PR TITLE
added basic validations

### DIFF
--- a/app/models/grid.rb
+++ b/app/models/grid.rb
@@ -1,3 +1,7 @@
 class Grid < ApplicationRecord
   has_many :pixels, dependent: :destroy
+
+  validates :height, presence: true, numericality: { only_integer: true }
+  validates :width, presence: true, numericality: { only_integer: true }
+  validates :pixel_size, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/pixel.rb
+++ b/app/models/pixel.rb
@@ -1,4 +1,7 @@
 class Pixel < ApplicationRecord
   belongs_to :grid
   has_many :placements, dependent: :destroy
+
+  validates :x, presence: true, numericality: { only_integer: true }
+  validates :y, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/placement.rb
+++ b/app/models/placement.rb
@@ -1,4 +1,10 @@
 class Placement < ApplicationRecord
   belongs_to :user
   belongs_to :pixel
+
+  # These colors are based on the 16 named HTML colors. (just for testing)
+  validates :color, presence: true, inclusion: { in: %w[aqua gray navy silver
+                                                        black green olive teal
+                                                        blue lime purple white
+                                                        fuchsia maroon red yellow] }
 end


### PR DESCRIPTION
Just some basic validations, definitely need improvement but should help us with testing etc.

When a model belongs to another such as pixel belonging to grid it is not necessary to add: 
**validates :grid, presence: true**

This is because activerecord automatically implements this validation behind the scenes.

The 16 chosen colours are from this website: https://www.december.com/html/spec/color16.html

They are not the prettiest and are just for testing purposes, we will change them in the future.