### PR TITLE
Changed data storage and read/write to binary system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'pg', '~> 0.21'
 gem 'puma'
 gem 'rails', '5.2.3'
 gem 'redis'
-gem 'oj'
 
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 5.6.1'

--- a/app/controllers/grids_controller.rb
+++ b/app/controllers/grids_controller.rb
@@ -9,3 +9,5 @@ class GridsController < ApplicationController
     @grid = Grid.find(params[:id])
   end
 end
+
+# trigger heroku update please

--- a/app/controllers/grids_controller.rb
+++ b/app/controllers/grids_controller.rb
@@ -9,5 +9,3 @@ class GridsController < ApplicationController
     @grid = Grid.find(params[:id])
   end
 end
-
-# trigger heroku update please

--- a/app/javascript/modules/init_grid.js
+++ b/app/javascript/modules/init_grid.js
@@ -3,13 +3,35 @@ const initGrid = () => {
   let canvas = document.getElementById('grid');
   let ctx = canvas.getContext('2d');
   if (canvas.getContext) {
-    // ctx is what we use to interact with the canvas
-    // Extracts and parses the pixelArray passed through the HTML dataset in show
-    // Probably should change this to an API/fetch request
-    let pixelArray = JSON.parse(canvas.dataset.pixelArray)
-    // Converts the pixelArray to a "Uint8ClampedArray" which is required to make ImageData
+    // Color values
+    const rgbas = {0: [255, 255, 255, 255],
+                  1: [87, 87, 87, 255],
+                  2: [173, 35, 35, 255],
+                  3: [42, 75, 215, 255],
+                  4: [29, 105, 20, 255],
+                  5: [129, 74, 25, 255],
+                  6: [129, 38, 192, 255],
+                  7: [160, 160, 160, 255],
+                  8: [129, 197, 122, 255],
+                  9: [157, 175, 255, 255],
+                  10: [41, 208, 208, 255],
+                  11: [255, 146, 51, 255],
+                  12: [255, 238, 51, 255],
+                  13: [233, 222, 187, 255],
+                  14: [255, 205, 243, 255],
+                  15: [0, 0, 0, 255]}
+
+    let pixelBits = canvas.dataset.pixelBits
+    let pixelArray = [];
+
+    // Converts each 4 bit number into an rgba and pushes it into pixelArray
+    for (let i = 0; i < pixelBits.length; i+= 4) {
+      rgbas[parseInt(pixelBits.slice(i, i + 4), 2)].forEach(int => pixelArray.push(int));
+    }
+
+    // Converts the pixelArray to a "Uint8ClampedArray" which is then required
+    // in the next line to build the imageData object
     let clampedPixelArray = Uint8ClampedArray.from(pixelArray)
-    // Creates the ImageData object from the clampedPixelArray
     let pixelGridData = new ImageData(clampedPixelArray, canvas.width, canvas.height);
     // Paint the pixelGridData to the canvas
     ctx.putImageData(pixelGridData, 0, 0);
@@ -18,11 +40,4 @@ const initGrid = () => {
   };
 };
 
-
-
-
-
 export { initGrid };
-
-// var dbgCanvasCoords = "Canvas coords:" + '\n' + "Zoom:" + d[0] + '\n' + "X:" + d[4] + '\n' + "Y:" + d[5];
-// var dbgMouseCoords = 'Mouse coords: ' + '\n' + "X:" + mousePos.x + '\n' + "Y:" + mousePos.y + "\n" + "Real X:" + Math.floor(mousePos.x / d[0]) + "\n" + "Real Y:" + Math.floor(mousePos.y / d[0]);

--- a/app/models/grid.rb
+++ b/app/models/grid.rb
@@ -3,22 +3,15 @@ class Grid < ApplicationRecord
 
   validates :height, presence: true, numericality: { only_integer: true }
   validates :width, presence: true, numericality: { only_integer: true }
-  validates :pixel_size, presence: true, numericality: { only_integer: true }
 
-  # Method for testing purposes, call .populate on a grid instance to populate it with..
-  # ..random coloured pixel.
+  # Method for testing purposes, call .populate on a grid instance to populate
+  # it with random coloured pixels.
   def populate
-    (width * height).times do
-      3.times { pixel_array << rand(0..255) }
-      pixel_array << 255
-    end
-    save!
-  end
-
-  def update_pixel(x, y, rgba)
-    start_index = 4 * (y * width + x)
-    (0..3).each { |i| pixel_array[start_index + i] = rgba[i] }
-    # It reaches here instantly however the save takes a couple seconds
+    bit_string = ""
+    # For each coordinate in the grid it picks a random number from 0-15 and
+    # converts it into a string of 4 bits
+    (width * height).times { bit_string << "%04b" % rand(15) }
+    self.pixel_bits = bit_string
     save!
   end
 end

--- a/app/views/grids/show.html.erb
+++ b/app/views/grids/show.html.erb
@@ -1,5 +1,5 @@
 <div id="stage">
-  <!-- This needs to change, currently passing 4mb worth of data through a tag -->
-  <canvas id="grid" height="<%= @grid.height %>", width="<%= @grid.width %>" data-pixel-array="<%= Oj.dump(@grid.pixel_array) %>"></canvas>
+  <canvas id="grid" height="<%= @grid.height %>", width="<%= @grid.width %>" data-pixel-bits="<%= @grid.pixel_bits %>"></canvas>
 </div>
+
 <button id="reset-zoom" class="btn btn-primary" onclick="stage.style.transform = 'matrix(0.85, 0, 0, 0.85, 525, 15)'">Reset View</button>

--- a/db/migrate/20190829093742_add_pixel_bits_to_grid.rb
+++ b/db/migrate/20190829093742_add_pixel_bits_to_grid.rb
@@ -1,0 +1,5 @@
+class AddPixelBitsToGrid < ActiveRecord::Migration[5.2]
+  def change
+    add_column :grids, :pixel_bits, "bit(4000000)"
+  end
+end

--- a/db/migrate/20190829123253_remove_pixel_array_from_grids.rb
+++ b/db/migrate/20190829123253_remove_pixel_array_from_grids.rb
@@ -1,0 +1,5 @@
+class RemovePixelArrayFromGrids < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :grids, :pixel_array
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_27_221040) do
+ActiveRecord::Schema.define(version: 2019_08_29_123253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2019_08_27_221040) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pixel_size"
-    t.integer "pixel_array", default: [], array: true
+    t.bit "pixel_bits", limit: 4000000
   end
 
   create_table "placements", force: :cascade do |t|


### PR DESCRIPTION
The whole grids data is stored as a bit string labeled pixel_bits. This string is passed to the javascript which unpacks it and converts each set of 4 bits to a number and then to the corresponding 32 bit rgba colour values. This is then painted onto the grid using putImageData().

I also removed the oj gem as we no longer need to convert the grid data to a json and back as it is just a string.

In total this reduced the page load time by about 95% :)