### PR TITLE
refactored to allow any grid size

### DIFF
--- a/db/migrate/20190830091307_change_pixel_bits_to_varying_bit_string.rb
+++ b/db/migrate/20190830091307_change_pixel_bits_to_varying_bit_string.rb
@@ -1,0 +1,5 @@
+class ChangePixelBitsToVaryingBitString < ActiveRecord::Migration[5.2]
+  def change
+    change_column :grids, :pixel_bits, "bit varying(4000000)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_29_123253) do
+ActiveRecord::Schema.define(version: 2019_08_30_091307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2019_08_29_123253) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pixel_size"
-    t.bit "pixel_bits", limit: 4000000
+    t.bit_varying "pixel_bits", limit: 4000000
   end
 
   create_table "placements", force: :cascade do |t|


### PR DESCRIPTION
Now allows any height and width, even different ones.

Current limitation is (height * width * 4) cannot be more than 4 million. This can be adjusted in the future if we want mega grids.

10x10 grid shown below:

![image](https://user-images.githubusercontent.com/51816032/64010538-43e24000-cb1a-11e9-8db5-cd968e925d1d.png)
