### PR TITLE
removed pixel_size column as it is no longer needed

### DIFF
--- a/db/migrate/20190831111824_remove_pixel_size_from_grids.rb
+++ b/db/migrate/20190831111824_remove_pixel_size_from_grids.rb
@@ -1,0 +1,5 @@
+class RemovePixelSizeFromGrids < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :grids, :pixel_size
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_30_091307) do
+ActiveRecord::Schema.define(version: 2019_08_31_111824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 2019_08_30_091307) do
     t.integer "width"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "pixel_size"
     t.bit_varying "pixel_bits", limit: 4000000
   end
 


### PR DESCRIPTION
Just a migration to remove the pixel_size column as we are no longer using it