### PR TITLE
added pixel db update method

### DIFF
--- a/app/models/grid.rb
+++ b/app/models/grid.rb
@@ -17,6 +17,14 @@ class Grid < ApplicationRecord
     save!
   end
 
+  def update_pixel(x, y, bit_string)
+    # This can be used to update and save any pixel on the grid to any color
+    start_index = (width * y + x) * 4
+    pixel_bits_will_change!
+    pixel_bits[start_index..(start_index + 3)] = bit_string
+    save!
+  end
+
   private
 
   def fill_bits


### PR DESCRIPTION
Call .update_pixel(x, y, bit_string) on a grid instance to update a pixel's color.

x = x coordinate
y = y coordinate
bit_string = string consisting of 4 bits referencing the color eg. "1001"

![image](https://user-images.githubusercontent.com/51816032/64074828-dcaac400-ccb0-11e9-996a-e2fd0d6d66f1.png)
