### PR TITLE
added batch updating and queue loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rails', '5.2.3'
 gem 'redis'
 gem 'sidekiq'
 gem 'sidekiq-failures', '~> 1.0'
+gem 'oj'
 
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass', '~> 5.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    oj (3.9.0)
     orm_adapter (0.5.0)
     pg (0.21.0)
     pry (0.12.2)
@@ -209,6 +210,7 @@ DEPENDENCIES
   font-awesome-sass (~> 5.6.1)
   jbuilder (~> 2.0)
   listen (~> 3.0.5)
+  oj
   pg (~> 0.21)
   pry-byebug
   pry-rails

--- a/app/controllers/api/v1/grids_controller.rb
+++ b/app/controllers/api/v1/grids_controller.rb
@@ -1,12 +1,8 @@
 class Api::V1::GridsController < Api::V1::BaseController
   def place_pixel
-    @grid = Grid.find(params[:id])
-    x = params[:x]
-    y = params[:y]
-    color_index = params[:colorIndex]
-    ActionCable.server.broadcast("grid_#{@grid.id}", x: x,
-                                                     y: y,
-                                                     colorIndex: color_index)
-    PixelUpdateJob.perform_later(grid_id: @grid.id, x: x, y: y, binary: "%04b" % color_index)
+    PixelUpdateJob.perform_later(grid_id: params[:id],
+                                 x: params[:x],
+                                 y: params[:y],
+                                 color_index: params[:colorIndex])
   end
 end

--- a/app/controllers/grids_controller.rb
+++ b/app/controllers/grids_controller.rb
@@ -7,5 +7,6 @@ class GridsController < ApplicationController
 
   def show
     @grid = Grid.find(params[:id])
+    @queue = @grid.queue
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,7 @@ class PagesController < ApplicationController
   def home
     # redirect_to grid_path(Grid.last)
     @grid = Grid.last
+    @queue = @grid.queue
     render 'grids/show'
   end
 end

--- a/app/javascript/modules/init_grid.js
+++ b/app/javascript/modules/init_grid.js
@@ -3,6 +3,7 @@ const initGrid = () => {
   if (canvas.getContext) {
     let pixelBits = canvas.dataset.pixelBits
     let pixelArray = [];
+    const queue = JSON.parse(canvas.dataset.queue);
 
     // Converts each 4 bit number into an rgba and pushes it into pixelArray
     for (let i = 0; i < pixelBits.length; i+= 4) {
@@ -18,7 +19,14 @@ const initGrid = () => {
     ctx.webkitImageSmoothingEnabled = false;
     ctx.msImageSmoothingEnabled = false;
     ctx.imageSmoothingEnabled = false;
+
     ctx.putImageData(pixelGridData, 0, 0);
+
+    for (let i = 0; i < queue.length; i++) {
+      const placement = queue[i];
+      const pixel = new ImageData(Uint8ClampedArray.from(rgbas[placement[2]]), 1, 1);
+      ctx.putImageData(pixel, placement[0], placement[1]);
+    }
 
     canvas.style.boxShadow = "0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22)"
   } else {

--- a/app/jobs/pixel_update_job.rb
+++ b/app/jobs/pixel_update_job.rb
@@ -4,7 +4,9 @@ class PixelUpdateJob < ApplicationJob
   def perform(args = {})
     # Do something later
     @grid = Grid.find(args[:grid_id])
-    @grid.update_pixel(args[:x], args[:y], args[:binary])
-    # @grid.update_pixel(args.x, args.y, args.binary)
+    @grid.update_pixel([args[:x], args[:y], args[:color_index]])
+    ActionCable.server.broadcast("grid_#{@grid.id}", x: args[:x],
+                                                     y: args[:y],
+                                                     colorIndex: args[:color_index])
   end
 end

--- a/app/views/grids/show.html.erb
+++ b/app/views/grids/show.html.erb
@@ -1,6 +1,6 @@
 <div id="stage">
   <!-- The display: none, hides the grid until it's position has been set -->
-  <canvas id="grid" height="<%= @grid.height %>" width="<%= @grid.width %>" data-pixel-bits="<%= @grid.pixel_bits %>" data-id="<%= @grid.id %>" style="display: none;"></canvas>
+  <canvas id="grid" height="<%= @grid.height %>" width="<%= @grid.width %>" data-pixel-bits="<%= @grid.pixel_bits %>" data-id="<%= @grid.id %>" data-queue="<%= Oj.dump(@queue) %>" style="display: none;"></canvas>
 </div>
 
 <div class="cols-container">

--- a/db/migrate/20190904080719_add_pixel_queue_to_grids.rb
+++ b/db/migrate/20190904080719_add_pixel_queue_to_grids.rb
@@ -1,0 +1,5 @@
+class AddPixelQueueToGrids < ActiveRecord::Migration[5.2]
+  def change
+    add_column :grids, :queue, :integer, array:true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_03_211751) do
+ActiveRecord::Schema.define(version: 2019_09_04_080719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_09_03_211751) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bit_varying "pixel_bits", limit: 4000000
+    t.integer "queue", default: [], array: true
   end
 
   create_table "orders", force: :cascade do |t|


### PR DESCRIPTION
Pixel updates will be added into grids queue array, once the queue reaches a certain size (currently 100) it will update them all to the database in the correct order.

New users will load the db grid and then place all items from the queue in the correct order.